### PR TITLE
feat: relayer adoptions for reorgs

### DIFF
--- a/block_relayer/example.toml
+++ b/block_relayer/example.toml
@@ -6,6 +6,7 @@ yona_http = "http://devnet-rpc.yona.network:8899"
 yona_ws = "ws://devnet-rpc.yona.network:8900"
 # The file path to the Yona keypair JSON file. It is relative to the current user's home directory.
 yona_keipair = ".config/solana/id.json"
+btc_header_confirmations = 6
 btc_deposit_confirmations = 6
 btc_withdraw_confirmations = 6
 

--- a/block_relayer/src/config.rs
+++ b/block_relayer/src/config.rs
@@ -28,10 +28,16 @@ pub struct RelayConfig {
     pub yona_http: String,
     pub yona_ws: String,
     pub yona_keipair: String,
+    #[serde(default = "default_btc_header_confirmations")]
+    pub btc_header_confirmations: u32,
     #[serde(default = "default_btc_deposit_confirmations")]
     pub btc_deposit_confirmations: u32,
     #[serde(default = "default_btc_withdraw_confirmations")]
     pub btc_withdraw_confirmations: u32,
+}
+
+fn default_btc_header_confirmations() -> u32 {
+    6
 }
 
 fn default_btc_deposit_confirmations() -> u32 {

--- a/block_relayer/src/lib.rs
+++ b/block_relayer/src/lib.rs
@@ -44,13 +44,110 @@ use btc_relay::program::BtcRelay;
 use btc_relay::state::MainState;
 use btc_relay::utils::bridge_deposit_script;
 use btc_relay::utils::{compute_new_nbits, nbits_to_target};
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use solana_transaction_status::option_serializer::OptionSerializer;
 use sqlx::SqlitePool;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{env, error};
+
+const MAX_REORG_RECOVERY_DEPTH: u32 = 249;
+
+fn safe_bitcoin_height(best_block_height: u32, required_confirmations: u32) -> u32 {
+    best_block_height.saturating_sub(required_confirmations.saturating_sub(1))
+}
+
+fn last_diff_adjustment_height(block_height: u32) -> u32 {
+    block_height - (block_height % 2016)
+}
+
+fn last_diff_adjustment_for_height(
+    bitcoind_client: &BitcoinRpcClient,
+    block_height: u32,
+) -> Result<u32, BtcError> {
+    let adjustment_height = last_diff_adjustment_height(block_height);
+    let adjustment_hash = bitcoind_client.get_block_hash(adjustment_height as u64)?;
+    let adjustment_header = bitcoind_client.get_block_header(&adjustment_hash)?;
+    Ok(adjustment_header.time)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HeaderRelayAction {
+    WaitForSafeHeight { safe_height: u32 },
+    AheadOfSafeHeight { safe_height: u32 },
+    SubmitNext { new_height: u32 },
+    RecoverFork { fork_height: u32, safe_height: u32 },
+}
+
+fn decide_header_relay_action(
+    relay_tip_height: u32,
+    best_block_height: u32,
+    required_confirmations: u32,
+    tip_matches_chain: bool,
+    common_ancestor_height: Option<u32>,
+) -> HeaderRelayAction {
+    let safe_height = safe_bitcoin_height(best_block_height, required_confirmations);
+    if tip_matches_chain && relay_tip_height == safe_height {
+        return HeaderRelayAction::WaitForSafeHeight { safe_height };
+    }
+    if tip_matches_chain && relay_tip_height > safe_height {
+        return HeaderRelayAction::AheadOfSafeHeight { safe_height };
+    }
+
+    let new_height = relay_tip_height + 1;
+    if tip_matches_chain {
+        return HeaderRelayAction::SubmitNext { new_height };
+    }
+
+    let fork_height = common_ancestor_height
+        .map(|height| height + 1)
+        .unwrap_or(new_height);
+
+    HeaderRelayAction::RecoverFork {
+        fork_height,
+        safe_height,
+    }
+}
+
+fn find_common_ancestor(
+    bitcoind_client: &BitcoinRpcClient,
+    relay_tip_hash: BlockHash,
+    relay_tip_height: u32,
+) -> Result<Option<(u32, BlockHash)>, BtcError> {
+    let mut relay_hash = relay_tip_hash;
+    let mut relay_height = relay_tip_height;
+
+    for _ in 0..=MAX_REORG_RECOVERY_DEPTH {
+        let bitcoin_hash_at_height = bitcoind_client.get_block_hash(relay_height as u64)?;
+        if bitcoin_hash_at_height == relay_hash {
+            return Ok(Some((relay_height, relay_hash)));
+        }
+
+        if relay_height == 0 {
+            break;
+        }
+
+        let relay_header = bitcoind_client.get_block_header(&relay_hash)?;
+        relay_hash = relay_header.prev_blockhash;
+        relay_height -= 1;
+    }
+
+    Ok(None)
+}
+
+fn tip_matches_bitcoin_chain(
+    bitcoind_client: &BitcoinRpcClient,
+    relay_tip_hash: BlockHash,
+    relay_tip_height: u32,
+) -> Result<bool, BtcError> {
+    let bitcoin_hash_at_height = bitcoind_client.get_block_hash(relay_tip_height as u64)?;
+    Ok(bitcoin_hash_at_height == relay_tip_hash)
+}
+
+fn can_check_tip_consistency(relay_tip_height: u32, bitcoin_best_height: u32) -> bool {
+    bitcoin_best_height >= relay_tip_height
+}
 
 pub fn get_yona_client(
     config: &RelayConfig,
@@ -169,13 +266,227 @@ pub async fn relay_blocks_from_full_node(config: RelayConfig, wait_for_new_block
         set_block_height(MetricChain::BitcoinBest, best_block_height);
         set_block_height(MetricChain::YonaRelayTip, last_submitted_height);
 
-        if last_submitted_height >= best_block_height {
-            info!("Latest BTC block {best_block_height} is already submitted to Yona. Waiting for a new one.");
+        let relay_tip_hash = BlockHash::from_byte_array(main_state_data.tip_block_hash);
+        if !can_check_tip_consistency(last_submitted_height, best_block_height) {
+            warn!(
+                "Bitcoin node best height {} is behind relay tip {}. Waiting for backend to catch up.",
+                best_block_height,
+                last_submitted_height
+            );
             tokio::time::sleep(Duration::from_secs(wait_for_new_block)).await;
             continue;
         }
+        let tip_matches_chain = match tokio::task::block_in_place(|| {
+            tip_matches_bitcoin_chain(&bitcoind_client, relay_tip_hash, last_submitted_height)
+        }) {
+            Ok(matches) => matches,
+            Err(e) => {
+                error!(
+                    "Error {e} on Bitcoin tip consistency check at height {}",
+                    last_submitted_height
+                );
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                continue;
+            }
+        };
+
+        let header_action = if tip_matches_chain {
+            decide_header_relay_action(
+                last_submitted_height,
+                best_block_height,
+                config.btc_header_confirmations,
+                true,
+                None,
+            )
+        } else {
+            let common_ancestor = match tokio::task::block_in_place(|| {
+                find_common_ancestor(&bitcoind_client, relay_tip_hash, last_submitted_height)
+            }) {
+                Ok(Some(ancestor)) => ancestor,
+                Ok(None) => {
+                    error!(
+                        "Could not find a common ancestor within {} blocks of relay tip {} at height {}. Manual recovery is required.",
+                        MAX_REORG_RECOVERY_DEPTH,
+                        relay_tip_hash,
+                        last_submitted_height
+                    );
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    continue;
+                }
+                Err(e) => {
+                    error!("Error {e} while searching for a common ancestor");
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                    continue;
+                }
+            };
+
+            decide_header_relay_action(
+                last_submitted_height,
+                best_block_height,
+                config.btc_header_confirmations,
+                false,
+                Some(common_ancestor.0),
+            )
+        };
 
         let new_height = last_submitted_height + 1;
+
+        match header_action {
+            HeaderRelayAction::WaitForSafeHeight { safe_height } => {
+                info!(
+                    "Yona relay tip {} is caught up to safe BTC height {} (best {}, header confirmations {}). Waiting for a new safe block.",
+                    last_submitted_height,
+                    safe_height,
+                    best_block_height,
+                    config.btc_header_confirmations
+                );
+                tokio::time::sleep(Duration::from_secs(wait_for_new_block)).await;
+                continue;
+            }
+            HeaderRelayAction::AheadOfSafeHeight { safe_height } => {
+                warn!(
+                    "Yona relay tip {} is ahead of safe BTC height {} (best {}, header confirmations {}). Waiting for Bitcoin to catch up before applying delay policy.",
+                    last_submitted_height,
+                    safe_height,
+                    best_block_height,
+                    config.btc_header_confirmations
+                );
+                tokio::time::sleep(Duration::from_secs(wait_for_new_block)).await;
+                continue;
+            }
+            HeaderRelayAction::SubmitNext { .. } => {}
+            HeaderRelayAction::RecoverFork {
+                fork_height,
+                safe_height,
+            } => {
+                if fork_height > safe_height {
+                    warn!(
+                        "Relay tip mismatch at height {} but fork height {} is above safe BTC height {}. Waiting for confirmations.",
+                        last_submitted_height, fork_height, safe_height
+                    );
+                    tokio::time::sleep(Duration::from_secs(wait_for_new_block)).await;
+                    continue;
+                }
+                warn!(
+                    "Relay tip mismatch at height {}: Yona tip {} is no longer canonical. Starting fork recovery at height {}.",
+                    last_submitted_height,
+                    relay_tip_hash,
+                    fork_height
+                );
+
+                let common_ancestor = match tokio::task::block_in_place(|| {
+                    find_common_ancestor(&bitcoind_client, relay_tip_hash, last_submitted_height)
+                }) {
+                    Ok(Some(ancestor)) => ancestor,
+                    Ok(None) => {
+                        error!(
+                        "Could not find a common ancestor within {} blocks of relay tip {} at height {}. Manual recovery is required.",
+                        MAX_REORG_RECOVERY_DEPTH,
+                        relay_tip_hash,
+                        last_submitted_height
+                    );
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                    Err(e) => {
+                        error!("Error {e} while searching for a common ancestor");
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                };
+
+                let fork_block_hash = match tokio::task::block_in_place(|| {
+                    bitcoind_client.get_block_hash(fork_height as u64)
+                }) {
+                    Ok(hash) => hash,
+                    Err(e) => {
+                        error!(
+                        "Error {e} on Bitcoin's get_block_hash({fork_height}) during fork recovery"
+                    );
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                };
+
+                let fork_block = match tokio::task::block_in_place(|| {
+                    bitcoind_client.get_block(&fork_block_hash)
+                }) {
+                    Ok(block) => block,
+                    Err(e) => {
+                        error!("Error {e} on Bitcoin's get_block({fork_block_hash:02x}) during fork recovery");
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                };
+
+                let ancestor_last_diff_adjustment = match tokio::task::block_in_place(|| {
+                    last_diff_adjustment_for_height(&bitcoind_client, common_ancestor.0)
+                }) {
+                    Ok(timestamp) => timestamp,
+                    Err(e) => {
+                        error!(
+                            "Error {e} while loading last_diff_adjustment for common ancestor height {} during fork recovery",
+                            common_ancestor.0
+                        );
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                };
+
+                let prev_committed_header = match tokio::task::block_in_place(|| {
+                    reconstruct_commited_header(
+                        &bitcoind_client,
+                        &common_ancestor.1,
+                        common_ancestor.0,
+                        ancestor_last_diff_adjustment,
+                    )
+                }) {
+                    Ok(header) => header,
+                    Err(e) => {
+                        error!("Error {e} while reconstructing the common ancestor header during fork recovery");
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                };
+                let ancestor_chain_work = match tokio::task::block_in_place(|| {
+                    bitcoind_client.get_block_info(&common_ancestor.1)
+                }) {
+                    Ok(info) => chainwork_bytes_to_u256_be(&info.chainwork),
+                    Err(e) => {
+                        error!(
+                            "Error {e} while loading chainwork for common ancestor height {} during fork recovery",
+                            common_ancestor.0
+                        );
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                };
+                let mut prev_committed_header = prev_committed_header;
+                prev_committed_header.chain_work = ancestor_chain_work;
+
+                match submit_block_fork(
+                    &program,
+                    main_state,
+                    fork_block,
+                    fork_height,
+                    prev_committed_header,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        info!(
+                        "Recovered reorg by submitting fork block at height {} from common ancestor height {}",
+                        fork_height, common_ancestor.0
+                    );
+                    }
+                    Err(e) => {
+                        error!("Error {e:?} on fork recovery submit attempt");
+                        tokio::time::sleep(Duration::from_secs(10)).await;
+                    }
+                }
+                continue;
+            }
+        }
 
         let block_hash_to_submit =
             match tokio::task::block_in_place(|| bitcoind_client.get_block_hash(new_height as u64))
@@ -198,6 +509,15 @@ pub async fn relay_blocks_from_full_node(config: RelayConfig, wait_for_new_block
                 continue;
             }
         };
+
+        if block_to_submit.header.prev_blockhash != relay_tip_hash {
+            error!(
+                "Bitcoin height {} no longer builds on relay tip {} after consistency check. Retrying.",
+                new_height, relay_tip_hash
+            );
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            continue;
+        }
 
         if new_height % 2016 == 0 {
             let prev_hash = tokio::task::block_in_place(|| {
@@ -888,8 +1208,13 @@ pub async fn process_bridge_events(
 
 #[cfg(test)]
 mod tests {
+    use super::decide_header_relay_action;
     use super::finalize_withdrawal_in_db;
+    use super::can_check_tip_consistency;
+    use super::last_diff_adjustment_height;
     use super::reconcile_pending_withdrawals;
+    use super::safe_bitcoin_height;
+    use super::HeaderRelayAction;
     use crate::bridge_db::{
         init_test_pool, Utxo, WithdrawStatus, WithdrawTransactionInfo, UTXO_STATUS_CONFIRMED,
         UTXO_STATUS_PENDING_CHANGE, UTXO_STATUS_SPENT_PENDING,
@@ -942,6 +1267,136 @@ mod tests {
                 .create_wallet(wallet_name, None, None, None, None)
                 .unwrap();
         }
+    }
+
+    #[test]
+    fn test_safe_bitcoin_height_applies_header_delay() {
+        assert_eq!(safe_bitcoin_height(100, 6), 95);
+        assert_eq!(safe_bitcoin_height(6, 6), 1);
+        assert_eq!(safe_bitcoin_height(3, 6), 0);
+        assert_eq!(safe_bitcoin_height(100, 0), 100);
+    }
+
+    #[test]
+    fn test_last_diff_adjustment_height_uses_ancestor_epoch_boundary() {
+        assert_eq!(last_diff_adjustment_height(0), 0);
+        assert_eq!(last_diff_adjustment_height(1), 0);
+        assert_eq!(last_diff_adjustment_height(2015), 0);
+        assert_eq!(last_diff_adjustment_height(2016), 2016);
+        assert_eq!(last_diff_adjustment_height(4031), 2016);
+        assert_eq!(last_diff_adjustment_height(4032), 4032);
+    }
+
+    #[test]
+    fn test_can_check_tip_consistency_only_when_bitcoin_backend_has_the_height() {
+        assert!(can_check_tip_consistency(95, 95));
+        assert!(can_check_tip_consistency(95, 100));
+        assert!(!can_check_tip_consistency(100, 95));
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_waits_when_tip_is_at_safe_height() {
+        let action = decide_header_relay_action(95, 100, 6, true, None);
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::WaitForSafeHeight { safe_height: 95 }
+        );
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_marks_ahead_of_safe_tip_as_non_compliant() {
+        let action = decide_header_relay_action(100, 100, 6, true, None);
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::AheadOfSafeHeight { safe_height: 95 }
+        );
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_submits_next_when_parent_matches_and_safe() {
+        let action = decide_header_relay_action(94, 100, 6, true, None);
+
+        assert_eq!(action, HeaderRelayAction::SubmitNext { new_height: 95 });
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_recovers_fork_once_fork_block_is_safe() {
+        let action = decide_header_relay_action(94, 100, 6, false, Some(93));
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::RecoverFork {
+                fork_height: 94,
+                safe_height: 95
+            }
+        );
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_recovers_reorg_at_safe_boundary_without_exceeding_it() {
+        let action = decide_header_relay_action(95, 101, 6, false, Some(95));
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::RecoverFork {
+                fork_height: 96,
+                safe_height: 96
+            }
+        );
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_recovers_from_deeper_reorg_without_exceeding_safe_height() {
+        let action = decide_header_relay_action(94, 100, 6, false, Some(90));
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::RecoverFork {
+                fork_height: 91,
+                safe_height: 95
+            }
+        );
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_recovers_when_tip_is_orphaned_at_safe_height() {
+        let action = decide_header_relay_action(95, 100, 6, false, Some(94));
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::RecoverFork {
+                fork_height: 95,
+                safe_height: 95
+            }
+        );
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_recovers_when_ahead_of_safe_tip_is_orphaned() {
+        let action = decide_header_relay_action(100, 100, 6, false, Some(98));
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::RecoverFork {
+                fork_height: 99,
+                safe_height: 95
+            }
+        );
+    }
+
+    #[test]
+    fn test_decide_header_relay_action_identifies_recovery_above_safe_height() {
+        let action = decide_header_relay_action(100, 100, 6, false, Some(99));
+
+        assert_eq!(
+            action,
+            HeaderRelayAction::RecoverFork {
+                fork_height: 100,
+                safe_height: 95
+            }
+        );
     }
 
     #[tokio::test]

--- a/block_relayer/src/relay_program_interaction.rs
+++ b/block_relayer/src/relay_program_interaction.rs
@@ -42,6 +42,46 @@ use std::sync::Arc;
 const MAX_RAW_TX: usize = 1232;
 const MAX_B64_TX: usize = 1644;
 
+fn effective_deposit_confirmations(
+    btc_deposit_confirmations: u32,
+    btc_header_confirmations: u32,
+    relay_tip_height: u32,
+    bitcoin_best_height: u32,
+    tip_is_canonical: bool,
+) -> u32 {
+    let safe_height =
+        bitcoin_best_height.saturating_sub(btc_header_confirmations.saturating_sub(1));
+    if tip_is_canonical && relay_tip_height <= safe_height {
+        btc_deposit_confirmations.saturating_sub(btc_header_confirmations.saturating_sub(1))
+    } else {
+        btc_deposit_confirmations
+    }
+}
+
+fn tip_is_canonical_for_deposits(
+    relay_tip_height: u32,
+    bitcoin_best_height: u32,
+    relay_tip_hash: BlockHash,
+    bitcoin_hash_at_relay_tip: Option<BlockHash>,
+) -> bool {
+    bitcoin_best_height >= relay_tip_height && bitcoin_hash_at_relay_tip == Some(relay_tip_hash)
+}
+
+fn deposit_height_is_safe(
+    tx_height: u32,
+    btc_header_confirmations: u32,
+    relay_tip_height: u32,
+    bitcoin_best_height: u32,
+) -> bool {
+    let safe_height =
+        bitcoin_best_height.saturating_sub(btc_header_confirmations.saturating_sub(1));
+    if relay_tip_height <= safe_height {
+        true
+    } else {
+        tx_height <= safe_height
+    }
+}
+
 pub(crate) fn reconstruct_commited_header(
     bitcoind_client: &BitcoinRpcClient,
     hash: &BlockHash,
@@ -92,7 +132,7 @@ impl From<BtcRpcError> for InitError {
 }
 
 // chainwork из bitcoind: big-endian bytes
-fn chainwork_bytes_to_u256_be(chainwork: &[u8]) -> [u8; 32] {
+pub(crate) fn chainwork_bytes_to_u256_be(chainwork: &[u8]) -> [u8; 32] {
     let mut out = [0u8; 32];
     if chainwork.is_empty() {
         return out;
@@ -396,7 +436,8 @@ pub async fn relay_tx(
     bitcoind_client: Arc<BitcoinRpcClient>,
     tx_id: Txid,
     wbtc_receiver_sol: Pubkey,
-    required_confirmations: u32,
+    btc_deposit_confirmations: u32,
+    btc_header_confirmations: u32,
 ) -> Result<Signature, RelayTxError> {
     inc_event(
         MetricFlow::DepositRelay,
@@ -419,6 +460,41 @@ pub async fn relay_tx(
         tokio::task::spawn_blocking(move || client_clone.get_raw_transaction_info(&tx_id, None))
             .await
             .expect("no panic")?;
+
+    let client_clone = bitcoind_client.clone();
+    let best_block_hash = tokio::task::spawn_blocking(move || client_clone.get_best_block_hash())
+        .await
+        .expect("no panic")?;
+    let client_clone = bitcoind_client.clone();
+    let best_block_info =
+        tokio::task::spawn_blocking(move || client_clone.get_block_info(&best_block_hash))
+            .await
+            .expect("no panic")?;
+    let bitcoin_hash_at_relay_tip = if best_block_info.height as u32 >= main_state_data.block_height {
+        let client_clone = bitcoind_client.clone();
+        Some(
+            tokio::task::spawn_blocking(move || {
+                client_clone.get_block_hash(main_state_data.block_height as u64)
+            })
+            .await
+            .expect("no panic")?,
+        )
+    } else {
+        None
+    };
+    let tip_is_canonical = tip_is_canonical_for_deposits(
+        main_state_data.block_height,
+        best_block_info.height as u32,
+        BlockHash::from_byte_array(main_state_data.tip_block_hash),
+        bitcoin_hash_at_relay_tip,
+    );
+    let required_confirmations = effective_deposit_confirmations(
+        btc_deposit_confirmations,
+        btc_header_confirmations,
+        main_state_data.block_height,
+        best_block_info.height as u32,
+        tip_is_canonical,
+    );
 
     let block_hash = match transaction.blockhash {
         Some(hash) => hash,
@@ -457,6 +533,19 @@ pub async fn relay_tx(
             MetricReason::BelowRelayBuffer,
         );
         return Err(RelayTxError::TxIsNotIncludedToBlockBuffer);
+    }
+    if !deposit_height_is_safe(
+        tx_height,
+        btc_header_confirmations,
+        main_state_data.block_height,
+        best_block_info.height as u32,
+    ) {
+        inc_event(
+            MetricFlow::DepositRelay,
+            MetricEventStatus::Rejected,
+            MetricReason::AheadOfRelayTip,
+        );
+        return Err(RelayTxError::TxIsNotIncludedToBlock);
     }
 
     let commit_hash = main_state_data.get_commitment(tx_height);
@@ -672,6 +761,88 @@ pub async fn relay_tx(
         );
 
         Ok(sig)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        chainwork_bytes_to_u256_be, deposit_height_is_safe, effective_deposit_confirmations,
+        tip_is_canonical_for_deposits,
+    };
+    use bitcoin::hashes::Hash;
+    use bitcoin::BlockHash;
+
+    fn block_hash(byte: u8) -> BlockHash {
+        BlockHash::from_byte_array([byte; 32])
+    }
+
+    #[test]
+    fn test_effective_deposit_confirmations_offsets_header_delay() {
+        assert_eq!(effective_deposit_confirmations(6, 6, 95, 100, true), 1);
+        assert_eq!(effective_deposit_confirmations(12, 6, 95, 100, true), 7);
+        assert_eq!(effective_deposit_confirmations(3, 6, 95, 100, true), 0);
+        assert_eq!(effective_deposit_confirmations(6, 0, 100, 100, true), 6);
+    }
+
+    #[test]
+    fn test_effective_deposit_confirmations_do_not_reduce_while_relay_is_ahead_of_safe_height() {
+        assert_eq!(effective_deposit_confirmations(6, 6, 100, 100, true), 6);
+        assert_eq!(effective_deposit_confirmations(6, 6, 96, 100, true), 6);
+    }
+
+    #[test]
+    fn test_effective_deposit_confirmations_do_not_reduce_when_tip_is_not_canonical() {
+        assert_eq!(effective_deposit_confirmations(6, 6, 95, 100, false), 6);
+        assert_eq!(effective_deposit_confirmations(3, 6, 95, 100, false), 3);
+    }
+
+    #[test]
+    fn test_tip_is_canonical_for_deposits_requires_matching_hash() {
+        let relay_tip_hash = block_hash(1);
+        assert!(tip_is_canonical_for_deposits(
+            95,
+            100,
+            relay_tip_hash,
+            Some(relay_tip_hash)
+        ));
+        assert!(!tip_is_canonical_for_deposits(
+            95,
+            100,
+            relay_tip_hash,
+            Some(block_hash(2))
+        ));
+    }
+
+    #[test]
+    fn test_tip_is_canonical_for_deposits_requires_backend_to_reach_tip_height() {
+        let relay_tip_hash = block_hash(3);
+        assert!(!tip_is_canonical_for_deposits(
+            100,
+            95,
+            relay_tip_hash,
+            None
+        ));
+    }
+
+    #[test]
+    fn test_deposit_height_is_safe_when_relay_is_delayed() {
+        assert!(deposit_height_is_safe(95, 6, 95, 100));
+        assert!(deposit_height_is_safe(94, 6, 95, 100));
+    }
+
+    #[test]
+    fn test_deposit_height_is_not_safe_above_safe_height_when_relay_tip_is_ahead() {
+        assert!(!deposit_height_is_safe(98, 6, 100, 100));
+        assert!(deposit_height_is_safe(95, 6, 100, 100));
+    }
+
+    #[test]
+    fn test_chainwork_bytes_to_u256_be_preserves_big_endian_value() {
+        let chainwork = [0x12u8, 0x34, 0x56];
+        let converted = chainwork_bytes_to_u256_be(&chainwork);
+        assert_eq!(&converted[29..], &chainwork);
+        assert!(converted[..29].iter().all(|byte| *byte == 0));
     }
 }
 

--- a/block_relayer/src/relay_transactions.rs
+++ b/block_relayer/src/relay_transactions.rs
@@ -11,7 +11,6 @@ use anchor_client::Program;
 use bitcoin::{Address, Network, Txid};
 use bitcoincore_rpc::Client as BitcoinRpcClient;
 use bitcoincore_rpc::Error as BtcError;
-
 use btc_relay::program::BtcRelay;
 use btc_relay::utils::bridge_deposit_script;
 use futures::future::join_all;
@@ -23,13 +22,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::get_yona_client;
-
 pub struct RelayTransactionsState {
     pub relay_program: Program<Arc<Keypair>>,
     pub bitcoin_rpc_client: Arc<BitcoinRpcClient>,
     pub sqlite_pool: SqlitePool,
     pub deposit_pubkey_hash: [u8; 20],
     pub main_state: Pubkey,
+    pub btc_header_confirmations: u32,
     pub btc_deposit_confirmations: u32,
 }
 
@@ -59,6 +58,7 @@ async fn relay_tx_web_api(
         tx_id,
         mint_receiver,
         data.btc_deposit_confirmations,
+        data.btc_header_confirmations,
     )
     .await;
 
@@ -239,6 +239,7 @@ pub async fn relay_transactions(
         main_state,
         deposit_pubkey_hash,
         sqlite_pool,
+        btc_header_confirmations: config.btc_header_confirmations,
         btc_deposit_confirmations: config.btc_deposit_confirmations,
     });
 
@@ -262,4 +263,10 @@ pub async fn relay_transactions(
     .run()
     .await
     .expect("HTTP server hasn't gracefully stop");
+}
+
+#[cfg(test)]
+mod tests {
+    // Deposit confirmation logic is tested in relay_program_interaction where the
+    // same main_state snapshot is used for both the reduction and the proof.
 }


### PR DESCRIPTION
This PR makes the Bitcoin relayer materially safer against short reorgs and able to recover automatically in the common recent-reorg case.
It adds delayed header relay to Yona, continuously verifies that the relayed tip is still canonical on Bitcoin, and only performs automatic fork recovery up to the configured safe height. 
Deposit relay was tightened as well: reduced confirmation thresholds now apply only when the relayed tip is both delayed and canonical, and deposits above the safe height are rejected while the relay is still ahead of policy.
